### PR TITLE
Extend the API to query the top 10 players by day/week/month

### DIFF
--- a/backend.Tests/Controllers/HighScoreControllerTests.cs
+++ b/backend.Tests/Controllers/HighScoreControllerTests.cs
@@ -94,5 +94,92 @@ namespace backend.Tests.Controllers
                 Assert.Equal("Invalid highscore entry", badRequestResult.Value);
             }
         }
+
+        [Fact]
+        public async Task GetTop10ByDay_ReturnsHighScores()
+        {
+            // Arrange
+            using (var context = new HighScoreDbContext(_dbContextOptions))
+            {
+                context.HighScores.AddRange(
+                    new HighScoreEntry { PlayerName = "Player1", Score = 100, DateAchieved = System.DateTime.Today },
+                    new HighScoreEntry { PlayerName = "Player2", Score = 200, DateAchieved = System.DateTime.Today },
+                    new HighScoreEntry { PlayerName = "Player3", Score = 300, DateAchieved = System.DateTime.Today.AddDays(-1) }
+                );
+                context.SaveChanges();
+            }
+
+            using (var context = new HighScoreDbContext(_dbContextOptions))
+            {
+                var controller = new HighScoreController(_loggerMock.Object, context);
+
+                // Act
+                var result = await controller.GetTop10ByDay();
+
+                // Assert
+                var okResult = Assert.IsType<OkObjectResult>(result.Result);
+                var highScores = Assert.IsAssignableFrom<IEnumerable<HighScoreEntryDto>>(okResult.Value);
+                Assert.Equal(2, highScores.Count());
+                Assert.Equal("Player2", highScores.First().PlayerName); // Highest score first
+            }
+        }
+
+        [Fact]
+        public async Task GetTop10ByWeek_ReturnsHighScores()
+        {
+            // Arrange
+            using (var context = new HighScoreDbContext(_dbContextOptions))
+            {
+                context.HighScores.AddRange(
+                    new HighScoreEntry { PlayerName = "Player1", Score = 100, DateAchieved = System.DateTime.Today },
+                    new HighScoreEntry { PlayerName = "Player2", Score = 200, DateAchieved = System.DateTime.Today.AddDays(-3) },
+                    new HighScoreEntry { PlayerName = "Player3", Score = 300, DateAchieved = System.DateTime.Today.AddDays(-10) }
+                );
+                context.SaveChanges();
+            }
+
+            using (var context = new HighScoreDbContext(_dbContextOptions))
+            {
+                var controller = new HighScoreController(_loggerMock.Object, context);
+
+                // Act
+                var result = await controller.GetTop10ByWeek();
+
+                // Assert
+                var okResult = Assert.IsType<OkObjectResult>(result.Result);
+                var highScores = Assert.IsAssignableFrom<IEnumerable<HighScoreEntryDto>>(okResult.Value);
+                Assert.Equal(2, highScores.Count());
+                Assert.Equal("Player2", highScores.First().PlayerName); // Highest score first
+            }
+        }
+
+        [Fact]
+        public async Task GetTop10ByMonth_ReturnsHighScores()
+        {
+            // Arrange
+            using (var context = new HighScoreDbContext(_dbContextOptions))
+            {
+                context.HighScores.AddRange(
+                    new HighScoreEntry { PlayerName = "Player1", Score = 100, DateAchieved = System.DateTime.Today },
+                    new HighScoreEntry { PlayerName = "Player2", Score = 200, DateAchieved = System.DateTime.Today.AddDays(-10) },
+                    new HighScoreEntry { PlayerName = "Player3", Score = 300, DateAchieved = System.DateTime.Today.AddMonths(-1) }
+                );
+                context.SaveChanges();
+            }
+
+            using (var context = new HighScoreDbContext(_dbContextOptions))
+            {
+                var controller = new HighScoreController(_loggerMock.Object, context);
+
+                // Act
+                var result = await controller.GetTop10ByMonth();
+
+                // Assert
+                var okResult = Assert.IsType<OkObjectResult>(result.Result);
+                var highScores = Assert.IsAssignableFrom<IEnumerable<HighScoreEntryDto>>(okResult.Value);
+                Assert.Equal(2, highScores.Count());
+                Assert.Equal("Player2", highScores.First().PlayerName); // Highest score first
+            }
+        }
     }
 }

--- a/backend/Controllers/HighScoreController.cs
+++ b/backend/Controllers/HighScoreController.cs
@@ -33,6 +33,54 @@ public class HighScoreController : ControllerBase
         return Ok(highScoreDtos);
     }
 
+    // GET api/highscore/top10byday
+    [HttpGet("top10byday")]
+    public async Task<ActionResult<IEnumerable<HighScoreEntryDto>>> GetTop10ByDay()
+    {
+        var today = DateTime.Today;
+        var highScores = await _context.HighScores
+            .Where(h => h.DateAchieved >= today)
+            .OrderByDescending(h => h.Score)
+            .Take(10)
+            .ToListAsync();
+
+        var highScoreDtos = highScores.Select(h => HighScoreEntryMapper.ToDto(h)).ToList();
+
+        return Ok(highScoreDtos);
+    }
+
+    // GET api/highscore/top10byweek
+    [HttpGet("top10byweek")]
+    public async Task<ActionResult<IEnumerable<HighScoreEntryDto>>> GetTop10ByWeek()
+    {
+        var startOfWeek = DateTime.Today.AddDays(-(int)DateTime.Today.DayOfWeek);
+        var highScores = await _context.HighScores
+            .Where(h => h.DateAchieved >= startOfWeek)
+            .OrderByDescending(h => h.Score)
+            .Take(10)
+            .ToListAsync();
+
+        var highScoreDtos = highScores.Select(h => HighScoreEntryMapper.ToDto(h)).ToList();
+
+        return Ok(highScoreDtos);
+    }
+
+    // GET api/highscore/top10bymonth
+    [HttpGet("top10bymonth")]
+    public async Task<ActionResult<IEnumerable<HighScoreEntryDto>>> GetTop10ByMonth()
+    {
+        var startOfMonth = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
+        var highScores = await _context.HighScores
+            .Where(h => h.DateAchieved >= startOfMonth)
+            .OrderByDescending(h => h.Score)
+            .Take(10)
+            .ToListAsync();
+
+        var highScoreDtos = highScores.Select(h => HighScoreEntryMapper.ToDto(h)).ToList();
+
+        return Ok(highScoreDtos);
+    }
+
     // POST api/highscore
     [HttpPost]
     public async Task<IActionResult> Post([FromBody] HighScoreEntryDto highScoreEntryDto)


### PR DESCRIPTION
Add new API endpoints to query top 10 players by day, week, and month.

* **HighScoreController.cs**
  - Add `GetTop10ByDay` method to retrieve top 10 players for the current day.
  - Add `GetTop10ByWeek` method to retrieve top 10 players for the current week.
  - Add `GetTop10ByMonth` method to retrieve top 10 players for the current month.

* **HighScoreControllerTests.cs**
  - Add `GetTop10ByDay_ReturnsHighScores` test to verify top 10 players for the current day.
  - Add `GetTop10ByWeek_ReturnsHighScores` test to verify top 10 players for the current week.
  - Add `GetTop10ByMonth_ReturnsHighScores` test to verify top 10 players for the current month.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/marc-mueller/pipelineinvaders?shareId=c764c40a-711f-477f-b86b-9379f453dcc3).